### PR TITLE
Upgrade to PHP 7.1, keeping xdebug for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM centos/httpd:latest
 MAINTAINER darkoantic
 
+COPY scripts/ /
+
 # Update and install latest packages and prerequisites
 RUN yum clean all && yum makecache fast \
     && yum -y install https://mirror.webtatic.com/yum/el7/webtatic-release.rpm && yum -y update \
-    && yum -y install git composer php70w php70w-opcache php70w-cli php70w-common php70w-mysql php70w-mbstring php70w-pecl-redis \
-    && yum -y install php70w-pecl-xdebug.x86_64 \
-    && yum -y install tcping which && yum clean all
+    && yum -y install git php71w-cli mod_php71w.x86_64 php71w-opcache php71w-common php71w-mysql php71w-mbstring php71w-pecl-redis \
+    && yum -y install php71w-pecl-xdebug.x86_64 \
+    && yum -y install tcping which wget && yum clean all \
+    && chmod +x /install-composer.sh && /install-composer.sh && rm /install-composer.sh \
+    && mv /composer.phar /usr/bin/composer && chmod a+x /usr/bin/composer
 
 COPY config/php.ini /etc/php.ini
 

--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# See https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
Note: for some reason, the `composer` yum package has a dependency conflict
with PHP 7.1, so I changed this to install the latest composer.phar from the
web, then move into /usr/bin.